### PR TITLE
Convert dangling JavaDoc comments to normal comments

### DIFF
--- a/src/main/java/market/hytale/game/api/web/HytaleWebAPIManager.java
+++ b/src/main/java/market/hytale/game/api/web/HytaleWebAPIManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Hytale Market
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/market/hytale/game/api/web/HytaleWebAPIService.java
+++ b/src/main/java/market/hytale/game/api/web/HytaleWebAPIService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Hytale Market
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/market/hytale/game/api/web/blog/AbstractBlogPost.java
+++ b/src/main/java/market/hytale/game/api/web/blog/AbstractBlogPost.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/market/hytale/game/api/web/blog/BlogPost.java
+++ b/src/main/java/market/hytale/game/api/web/blog/BlogPost.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/market/hytale/game/api/web/blog/BlogPostDetailed.java
+++ b/src/main/java/market/hytale/game/api/web/blog/BlogPostDetailed.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/market/hytale/game/api/web/blog/BlogPostDetailedNavigable.java
+++ b/src/main/java/market/hytale/game/api/web/blog/BlogPostDetailedNavigable.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/market/hytale/game/api/web/blog/BlogPostPreview.java
+++ b/src/main/java/market/hytale/game/api/web/blog/BlogPostPreview.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/market/hytale/game/api/web/blog/CoverImage.java
+++ b/src/main/java/market/hytale/game/api/web/blog/CoverImage.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/market/hytale/game/api/web/job/HiringOrganization.java
+++ b/src/main/java/market/hytale/game/api/web/job/HiringOrganization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Hytale Market
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/market/hytale/game/api/web/job/Job.java
+++ b/src/main/java/market/hytale/game/api/web/job/Job.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Hytale Market
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/market/hytale/game/api/web/job/JobLocation.java
+++ b/src/main/java/market/hytale/game/api/web/job/JobLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Hytale Market
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/market/hytale/game/api/web/test/BlogTest.java
+++ b/src/test/java/market/hytale/game/api/web/test/BlogTest.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/market/hytale/game/api/web/test/JobTest.java
+++ b/src/test/java/market/hytale/game/api/web/test/JobTest.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/market/hytale/game/api/web/test/TestUtils.java
+++ b/src/test/java/market/hytale/game/api/web/test/TestUtils.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright 2019 Hytale Market
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
All classes declare a comment at the top of the class (first line) containing licensing information. All those comments are dangling JavaDoc comments which just looks wrong so I converted them to normal block comments.